### PR TITLE
unload the web engine when disposing of the desktop web view

### DIFF
--- a/mediaplayer-kmp/src/jvmMain/kotlin/DesktopWebView.kt
+++ b/mediaplayer-kmp/src/jvmMain/kotlin/DesktopWebView.kt
@@ -28,7 +28,14 @@ fun DesktopWebView(
         modifier = modifier,
     )
 
-    DisposableEffect(url) { onDispose { jPanel.remove(jfxPanel) } }
+    DisposableEffect(url) {
+        onDispose {
+            Platform.runLater {
+                (jfxPanel.scene?.root as? WebView)?.engine?.load("")
+            }
+            jPanel.remove(jfxPanel)
+        }
+    }
 }
 
 private fun JFXPanel.buildWebView(url: String, onLoadingChange: (Boolean) -> Unit) {


### PR DESCRIPTION
Prevent having a white rectangle when trying to load another url.

I would have liked to find a more elegant way, but it is the only way I found (see https://stackoverflow.com/questions/22436498/how-to-stop-webengine-after-closing-stage-javafx)